### PR TITLE
Fix clictopay integration & bump supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ClicToPay-Monétique-Tunisie-2020
 
-**WooCommerce SMT ClicToPay** est un module **Wordpress** de paiement en ligne pour **SPS Monétique Tunisie**.
+**WooCommerce SMT ClicToPay** est un module **WordPress** de paiement en ligne pour **SPS Monétique Tunisie**.
 
 
 **Caractéristiques et fonctionnalités du module WooCommerce SMT ClicToPay** :
 
-- Compatible avec la version wordpress 5.5.1.
+- Compatible avec la version wordpress 6.6.1.
 
-- Compatible avec la version WooCommerce 4.5.2.
+- Compatible avec la version WooCommerce 7.3.0.
 
 - Accepter les paiements par carte de crédit tunisienne.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,13 @@
 # ClicToPay-Monétique-Tunisie-2020
 
-**WooCommerce SMT ClicToPay** est un module **Wordpress** de paiement en ligne pour **SPS Monétique Tunisie**.
+**WooCommerce SMT ClicToPay** est un module **WordPress** de paiement en ligne pour **SPS Monétique Tunisie**.
 
 
 **Caractéristiques et fonctionnalités du module WooCommerce SMT ClicToPay** :
 
-- Compatible avec la version wordpress 5.5.1.
+- Compatible avec la version wordpress 6.6.1.
 
-- Compatible avec la version WooCommerce 4.5.2.
+- Compatible avec la version WooCommerce 7.3.0.
 
 - Accepter les paiements par carte de crédit tunisienne.
 

--- a/woocommerce-smt-clictopay.php
+++ b/woocommerce-smt-clictopay.php
@@ -175,7 +175,7 @@ function wc_ctp_init_credit_card_gateway_class()
 
             $body = json_decode($response['body'], true);
 
-            if (isset($body['errorCode'])) {
+            if (isset($body['errorCode']) && (int)$body['errorCode'] !== 0) {
                 wc_add_notice($body['errorMessage'], 'error');
                 return;
             }


### PR DESCRIPTION
Since their last (really bad handled) update, `errorCode` is always present in the response, wether it failed or not 😒 
This PR fixes it and bump supported versions with what I tested.